### PR TITLE
Fix #42: `OpenGLEx.ConstructFor` sometimes does weird things

### DIFF
--- a/Castaway.Level.OpenGL/CameraController.cs
+++ b/Castaway.Level.OpenGL/CameraController.cs
@@ -32,8 +32,7 @@ namespace Castaway.Level.OpenGL
                 new(new Vector3(1, -1, 0), texture: new Vector3(1, 0, 0)),
                 new(new Vector3(-1, 1, 0), texture: new Vector3(0, 1, 0)),
                 new(new Vector3(1, 1, 0), texture: new Vector3(1, 1, 0))
-            }, new uint[] {0, 1, 2, 1, 3, 2}).ConstructUnoptimisedFor(BuiltinShaders.DirectTextured);
-            // TODO Work around unoptimised fullscreen buffer.
+            }, new uint[] {0, 1, 2, 1, 3, 2}).ConstructFor(BuiltinShaders.DirectTextured);
 
             Logger.Debug("Created new camera {Type} filling {ID}", GetType(), CameraID);
         }

--- a/Castaway.OpenGL/OpenGLEx.cs
+++ b/Castaway.OpenGL/OpenGLEx.cs
@@ -116,10 +116,9 @@ namespace Castaway.OpenGL
             };
         }
 
+        [Obsolete("Use " + nameof(ConstructFor) + " instead")]
         public static Drawable ConstructUnoptimisedFor(this Mesh mesh, ShaderObject shader)
         {
-            Logger.Warning("Refrain from using {FunctionName}; use {Replacement}", nameof(ConstructUnoptimisedFor),
-                nameof(ConstructFor));
             var vertexBuffer = new Buffer(BufferTarget.VertexArray, mesh.ConstructVertexArray(shader));
             var elementBuffer = new Buffer(BufferTarget.ElementArray, mesh.Elements);
 

--- a/Castaway.OpenGL/OpenGLImpl.cs
+++ b/Castaway.OpenGL/OpenGLImpl.cs
@@ -185,6 +185,7 @@ namespace Castaway.OpenGL
                 BindVAO(vaoDraw.VAO);
                 if (!vaoDraw.SetUp)
                 {
+                    buffer.VertexArray.Bind();
                     s.Binder!.Apply(v);
                     vaoDraw.SetUp = true;
                 }


### PR DESCRIPTION
This pull request binds the `VertexArrayBuffer`'s `VertexArray` before applying the vertex attributes, which fixes #42. It also changes OpenGL's `CameraController` to use the `ConstructFor` method, as it is now usable.