### PR TITLE
Add `AssetCache`

### DIFF
--- a/Castaway.Assets/AssetCache.cs
+++ b/Castaway.Assets/AssetCache.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Castaway.Base;
+using Serilog;
+
+namespace Castaway.Assets
+{
+    public class AssetCache
+    {
+        private static readonly ILogger Logger = CastawayGlobal.GetLogger();
+
+        private readonly Dictionary<string, object?> _data = new();
+
+        private string GenerateName(string id, Type objType) =>
+            '{' + new StackTrace().GetFrames()[2].GetMethod()!.DeclaringType!.AssemblyQualifiedName + '}' +
+            id +
+            ":{" + objType.AssemblyQualifiedName + '}';
+
+        public T Cache<T>(string id, T obj)
+        {
+            _data[GenerateName(id, typeof(T))] = obj;
+            Logger.Debug("Cached asset {ID}, which is {$ObjectType}", id, obj);
+            return obj;
+        }
+
+        public bool IsCached<T>(string id)
+        {
+            return _data.ContainsKey(GenerateName(id, typeof(T)));
+        }
+
+        public T Get<T>(string id)
+        {
+            var d = _data[GenerateName(id, typeof(T))];
+            return d is T t ? t : throw new InvalidOperationException($"Somehow, {id} is an invalid type");
+        }
+    }
+}

--- a/Castaway.Assets/AssetLoader.cs
+++ b/Castaway.Assets/AssetLoader.cs
@@ -12,6 +12,8 @@ namespace Castaway.Assets
 
         private Dictionary<string, (string, IAssetType)> Assets;
 
+        public AssetCache Cache = new();
+
         public AssetLoader()
         {
             Assets = new Dictionary<string, (string, IAssetType)>();

--- a/Castaway.Level.OpenGL/MeshController.cs
+++ b/Castaway.Level.OpenGL/MeshController.cs
@@ -2,6 +2,7 @@ using Castaway.Assets;
 using Castaway.Base;
 using Castaway.OpenGL;
 using Castaway.Rendering.Structures;
+using Serilog;
 
 namespace Castaway.Level.OpenGL
 {
@@ -9,14 +10,40 @@ namespace Castaway.Level.OpenGL
     [Imports(typeof(OpenGLImpl))]
     public class MeshController : Controller
     {
+        private static readonly ILogger Logger = CastawayGlobal.GetLogger();
+
         [LevelSerialized("AssetPath")] public Asset? Asset;
+        [LevelSerialized("DisableCache")] public bool CacheDisabled = false;
 
         public Mesh? Mesh;
 
         public override void OnInit(LevelObject parent)
         {
             base.OnInit(parent);
-            Mesh = Asset!.Type.To<Mesh>(Asset);
+            if (CacheDisabled) Mesh = ResolveNormally();
+            else
+            {
+                Mesh = AssetLoader.Loader!.Cache.IsCached<Mesh>(Asset!.Index)
+                    ? ResolveWithCache()
+                    : ResolveNormallyAndCache();
+            }
+        }
+
+        private Mesh ResolveNormally()
+        {
+            return Asset!.Type.To<Mesh>(Asset);
+        }
+
+        private Mesh ResolveNormallyAndCache()
+        {
+            Logger.Debug("Caching {Asset} as {Type}", Asset!.Index, typeof(Mesh));
+            return AssetLoader.Loader!.Cache.Cache(Asset!.Index, ResolveNormally());
+        }
+
+        private Mesh ResolveWithCache()
+        {
+            Logger.Debug("Resolving {Asset} from cache as {Type}", Asset!.Index, typeof(Mesh));
+            return AssetLoader.Loader!.Cache.Get<Mesh>(Asset!.Index);
         }
     }
 }


### PR DESCRIPTION
This pull request adds an `AssetCache` object that is built to store fully processed items. The items can only be accessed from the type that created them, and must be collected into the same type it was added as. A global cache can be found in `AssetLoader.Loader.Cache`.

resolves #43